### PR TITLE
Убрать возможность класть предметы в лед

### DIFF
--- a/data/config/rare-ice.properties
+++ b/data/config/rare-ice.properties
@@ -1,5 +1,5 @@
 #Rare Ice Configuration
 #Tue Jun 14 12:40:04 UTC 2022
 probabilityOfRareIce=3
-allowInsertingItemsToIce=true
+allowInsertingItemsToIce=false
 


### PR DESCRIPTION
Эту возможность добавляет мод генерирующий лут во льду (rare-ice), но смысла самому класть предметы в лед не много и это только мешает. Например когда ставишь лодку на лед.